### PR TITLE
Fix logo on mobile (<640px width)

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -165,9 +165,12 @@ img {
 
 .site-avatar {
   float: left;
-  width: 70px;
+  margin-right: 20px;
+
+  // Constrain logo image dimensions
+  // (Natural image dimensions: 88x121, see ./images/dalmug_logo.png)
+  width: 51px;
   height: 70px;
-  margin-right: 15px;
 
   @include mobile {
     float: none;


### PR DESCRIPTION
The logo overlaps with the title when the enclosing `<a>` tag does not constrain its dimensions.

### Before
#### > 640px
<img width="826" alt="screen shot 2018-01-04 at 10 46 01 am" src="https://user-images.githubusercontent.com/1402235/34569034-e677f958-f13d-11e7-89d7-c46e1e37b077.png">

#### < 640px
<img width="639" alt="screen shot 2018-01-04 at 10 46 28 am" src="https://user-images.githubusercontent.com/1402235/34569042-ec8ae166-f13d-11e7-9e3d-c827181af8c1.png">

### After

#### > 640px
<img width="826" alt="screen shot 2018-01-04 at 10 45 39 am" src="https://user-images.githubusercontent.com/1402235/34569048-f1b2598a-f13d-11e7-9144-dd39f6e7270a.png">

#### < 640px
<img width="639" alt="screen shot 2018-01-04 at 10 47 23 am" src="https://user-images.githubusercontent.com/1402235/34569049-f432ec92-f13d-11e7-8aba-cd3bf56a4fd3.png">
